### PR TITLE
Avoid reordering files in the jar

### DIFF
--- a/src/main/java/de/dentrassi/maven/osgi/dp/AbstractDpMojo.java
+++ b/src/main/java/de/dentrassi/maven/osgi/dp/AbstractDpMojo.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     Jens Reimann <jreimann@redhat.com> - initial API and implementation
+ *     Cristiano De Alti <cristiano.dealti@eurotech.com>
  *******************************************************************************/
 package de.dentrassi.maven.osgi.dp;
 
@@ -23,8 +24,8 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -177,7 +178,7 @@ public abstract class AbstractDpMojo extends AbstractMojo {
         dpmf.getMainAttributes().putValue("DeploymentPackage-Version", dpVersion);
 
         try {
-            final Map<String, File> files = new HashMap<>();
+            final Map<String, File> files = new LinkedHashMap<>();
 
             fillFromDependencies(dpmf, files);
 


### PR DESCRIPTION
In special cases the order of the bundles in the deployment package is important: a host bundle along with its fragment(s) providing native libraries.

Typically, the host bundle loads the native library in a static block. If the fragment is not already there when the static method executes, the class is not marked as failed and is not usable.

The current release 0.4.0 uses an intermediate HashMap for the generation of the deployment package jar, thus reordering the bundles. By using a LinkedHashMap, the order of the additionalDependencies in the pom file or the order of the plugins in the Eclipse feature file is preserved.

For the use case described above this fix allows to have the fragment installed before the host.