### PR TITLE
Fix build failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,4 +33,4 @@ jobs:
       run: mvn -B test
 
     - name: Run integration tests
-      run: mvn -B verify -Pits
+      run: mvn -B verify -Pits -Dinvoker.streamLogs

--- a/src/it/test1/pom.xml
+++ b/src/it/test1/pom.xml
@@ -8,8 +8,8 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>0.25.0</tycho-version>
-		<tycho-extras-version>0.25.0</tycho-extras-version>
+		<tycho-version>1.1.0</tycho-version>
+		<tycho-extras-version>1.1.0</tycho-extras-version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
The build was failing because of:

```java
!ENTRY org.eclipse.equinox.p2.touchpoint.natives 4 0 2025-01-13 18:47:24.569
!MESSAGE FrameworkEvent ERROR
!STACK 0
org.osgi.framework.BundleException: Could not resolve module: org.eclipse.equinox.p2.touchpoint.natives [2]
  Unresolved requirement: Import-Package: org.eclipse.equinox.internal.p2.core.helpers
    -> Export-Package: org.eclipse.equinox.internal.p2.core.helpers; bundle-symbolic-name="org.eclipse.equinox.p2.core"; bundle-version="2.4.100.v20160102-2223"; version="0.0.0"; x-friends:="org.eclipse.equinox.frameworkadmin.test,  org.eclipse.equinox.p2.artifact.optimizers,  org.eclipse.equinox.p2.artifact.processors,  org.eclipse.equinox.p2.artifact.repository,  org.eclipse.equinox.p2.console,  org.eclipse.equinox.p2.director,  org.eclipse.equinox.p2.director.app,  org.eclipse.equinox.p2.directorywatcher,  org.eclipse.equinox.p2.download,  org.eclipse.equinox.p2.engine,  org.eclipse.equinox.p2.extensionlocation,  org.eclipse.equinox.p2.garbagecollector,  org.eclipse.equinox.p2.installer,  org.eclipse.equinox.p2.metadata,  org.eclipse.equinox.p2.metadata.repository,  org.eclipse.equinox.p2.operations,  org.eclipse.equinox.p2.publisher,  org.eclipse.equinox.p2.publisher.eclipse,  org.eclipse.equinox.p2.reconciler.dropins,  org.eclipse.equinox.p2.repository,  org.eclipse.equinox.p2.repository.tools,  org.eclipse.equinox.p2.repositoryoptimizer,  org.eclipse.equinox.p2.touchpoint.eclipse,  org.eclipse.equinox.p2.touchpoint.natives,  org.eclipse.equinox.p2.ui,  org.eclipse.equinox.p2.ui.admin,  org.eclipse.equinox.p2.ui.sdk,  org.eclipse.equinox.p2.ui.sdk.scheduler,  org.eclipse.equinox.p2.updatechecker,  org.eclipse.equinox.p2.updatechecker.app,  org.eclipse.equinox.p2.updatesite,  org.eclipse.equinox.p2.transport.ecf,  org.eclipse.equinox.p2.discovery.compatibility,  org.eclipse.equinox.p2.ui.discovery,  org.eclipse.equinox.p2.discovery"
       org.eclipse.equinox.p2.core [37]
         Unresolved requirement: Require-Bundle: org.eclipse.equinox.common; bundle-version="[3.5.0,4.0.0)"
           -> Bundle-SymbolicName: org.eclipse.equinox.common; bundle-version="3.8.0.v20160315-1450"; singleton:="true"
              org.eclipse.equinox.common [49]
                Unresolved requirement: Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.7))"

	at org.eclipse.osgi.container.Module.start(Module.java:434)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.incStartLevel(ModuleContainer.java:1582)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.incStartLevel(ModuleContainer.java:1561)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.doContainerStartLevel(ModuleContainer.java:1533)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1476)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1)
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)
	at org.eclipse.osgi.framework.eventmgr.EventManager$EventThread.run(EventManager.java:340)
```

Please note that remote repository usage was added because without it, logback-classic was never resolved.